### PR TITLE
Add measurement time to measurements.

### DIFF
--- a/migrations/20231108192239-updateUpdatedAtToMeasuredAt.js
+++ b/migrations/20231108192239-updateUpdatedAtToMeasuredAt.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    return queryInterface.renameColumn('Measurements', 'updatedAt', 'measuredAt');
+  },
+
+  async down (queryInterface, Sequelize) {
+    return queryInterface.renameColumn('Measurements', 'measuredAt', 'updatedAt');
+  }
+};

--- a/models/measurements.js
+++ b/models/measurements.js
@@ -19,6 +19,7 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     sequelize,
     modelName: 'Measurements',
+    updatedAt: 'measuredAt'
   });
   return Measurements;
 };

--- a/seeders/20231105165601-demo-measurements.js
+++ b/seeders/20231105165601-demo-measurements.js
@@ -7,32 +7,32 @@ module.exports = {
          {
            temperature: 15,
            createdAt: '2023-11-05 12:00:00',
-           updatedAt: '2023-11-05 12:00:00'
+           measuredAt: '2023-11-05 12:00:00'
          },
        {
          temperature: 25,
          createdAt: '2023-08-13 13:52:00',
-         updatedAt: '2023-08-13 13:52:00'
+         measuredAt: '2023-08-13 13:52:00'
        },
        {
          temperature: 28,
          createdAt: '2023-07-01 06:25:00',
-         updatedAt: '2023-07-01 06:25:00'
+         measuredAt: '2023-07-01 06:25:00'
        },
        {
          temperature: 42,
          createdAt: '2022-06-05 03:14:00',
-         updatedAt: '2022-06-05 03:14:00'
+         measuredAt: '2022-06-05 03:14:00'
        },
        {
          temperature: 3,
          createdAt: '2023-10-08 15:00:00',
-         updatedAt: '2023-10-08 15:00:00'
+         measuredAt: '2023-10-08 15:00:00'
        },
        {
          temperature: 12,
          createdAt: '2023-10-10 15:32:00',
-         updatedAt: '2023-10-10 15:32:00',
+         measuredAt: '2023-10-10 15:32:00',
          deletedAt: '2023-10-15 12:00:00'
        }
       ], {});


### PR DESCRIPTION
Modifyed the name of "updatedAt" column in Measurements table to support defining exact time, a measurement was made.

If no time is provided, the measurement time is the same time than the creation time.