### PR TITLE
Handle timezones.

### DIFF
--- a/controllers/apicontroller.js
+++ b/controllers/apicontroller.js
@@ -15,6 +15,12 @@ eventEmitter.on('newMeasurement', async (data) => {
 });
 //////////////////////////////////////////////////////////////////////////////////////
 
+const modifyTimezone = (timestamp) => {
+    const CET = moment.tz(timestamp, "Europe/Paris");
+    const UTC = CET.clone().tz("Europe/London");
+
+    return UTC.format();
+}
 
 const getValues = async (req, res) => {
     const measurements = await Measurements.findAll( { where: { deletedAt: null }});
@@ -54,7 +60,13 @@ const storeValues = async (req, res) => {
         const measurementDevice = await Devices.findOne({ where: { uuid: device } });
 
         if (!measurementDevice) {
-            throw new Error("Device not found");
+            return res.status(404).json({
+                message: "Device not found"
+            });
+        }
+
+        if (measuredAt) {
+            measuredAt = modifyTimezone(measuredAt);
         }
 
         const result = await Measurements.create({

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "fs": "^0.0.1-security",
         "mariadb": "^3.2.2",
         "moment": "^2.29.4",
+        "moment-timezone": "^0.5.43",
         "mysql": "^2.18.1",
         "path": "^0.12.7",
         "process": "^0.11.10",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "fs": "^0.0.1-security",
     "mariadb": "^3.2.2",
     "moment": "^2.29.4",
+    "moment-timezone": "^0.5.43",
     "mysql": "^2.18.1",
     "path": "^0.12.7",
     "process": "^0.11.10",


### PR DESCRIPTION
Create a code to convert the CET timezone coming from the measurement device to UTC timezone, so all the timestamps in the database are in the same timezone.